### PR TITLE
fixed width of user details column in search table

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -14,12 +14,10 @@
  *= require_self
  */
 
+
+
 .picture{
   width: 100px;
-}
-
-.user-details{
-  width: 300px;
 }
 
 .table th {
@@ -37,4 +35,14 @@
 .profileimg {
   width:70px;
   border-radius: 100%;
+}
+
+.navbar-brand {
+  font-size: 500px;
+}
+
+td.user-details {
+  table-layout: fixed;
+  width: 300px;
+  word-break:break-all;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,12 +12,6 @@
     <div class="container-fluid">
       <!-- Brand and toggle get grouped for better mobile display -->
       <div class="navbar-header">
-        <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
-          <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-        </button>
         <a class="navbar-brand" href="/">InstaWonk</a>
       </div>
 

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 
 <%= form_tag(users_path, :method => 'get') do %>
   <%= label_tag :search, "Search" %>
-  <%= text_field_tag :search, params[:search], placeholder: "Search Users" %>
+  <%= text_field_tag :search, params[:search], placeholder: "Search bios" %>
   <%= submit_tag :Search %>
 <% end %>
 


### PR DESCRIPTION
Fixed width of user details column to prevent long strings from messing up the layout. Used "word-break: break-all;" in application.css to break strings up if too long for column width.
